### PR TITLE
Issue58: fix AssayLinks when parent assay are removed from the `Features` object

### DIFF
--- a/R/Features-class.R
+++ b/R/Features-class.R
@@ -214,8 +214,17 @@ setMethod("show", "Features",
 ##' @exportMethod [
 setMethod("[", c("Features", "ANY", "ANY", "ANY"),
           function(x, i, j, ..., drop = TRUE) {
+              ## Subset the assays
               ans <- callNextMethod(x, i, j, ..., drop)
+              ## Subset the AssayLinks
               ans@assayLinks <- ans@assayLinks[names(ans)]
+              ## Removed lost links
+              allist <- lapply(ans@assayLinks, function(al) {
+                  if(!al@from %in% names(ans)) al <- AssayLink(name = al@name)
+                  al
+              })
+              ans@assayLinks <- do.call(AssayLinks, allist)
+              ## Check new object
               if (validObject(ans))
                   return(ans)
           })

--- a/tests/testthat/test_Features.R
+++ b/tests/testthat/test_Features.R
@@ -44,6 +44,12 @@ test_that("addAssay", {
 })
 
 test_that("[,Features", {
+    data(feat1)
+    feat1 <- aggregateFeatures(feat1, "psms", "Sequence", "peptides")
+    expect_true(validObject(feat1[, , "psms"])) 
+    expect_true(validObject(feat1[, , "peptides"])) 
+    expect_true(validObject(feat1[, , 1])) 
+    expect_true(validObject(feat1[, , 2])) 
 })
 
 


### PR DESCRIPTION
When a parent assay is removed from a `Features` object (e.g. after subsetting), the `AssayLink` of the child assay is replaced by an empty `AssayLink` object. 

Related unit tests are added.