### PR TITLE
feat+test: aggregateFeatures returns proper class (see issue #78)

### DIFF
--- a/tests/testthat/test_aggregateFeatures.R
+++ b/tests/testthat/test_aggregateFeatures.R
@@ -124,3 +124,14 @@ test_that("aggregateFeatures: aggcounts", {
     ## .n variable
     expect_identical(rowData(se)$.n , c(2L, 2L))
 })
+
+test_that("aggregateFeatures return class (issue 78)", {
+    library(SingleCellExperiment)
+    f <- addAssay(feat1, as(feat1[[1]], "SingleCellExperiment"), name = "sce")
+    ## Aggregating an SEs produces an SE
+    expect_identical(class(aggregateFeatures(f, i = 1, fcol = "Sequence")[["newAssay"]])[1],
+                     "SummarizedExperiment")
+    ## Aggregating an SCEs produces an SCE
+    expect_identical(class(aggregateFeatures(f, i = 2, fcol = "Sequence")[["newAssay"]])[1],
+                     "SingleCellExperiment")
+})


### PR DESCRIPTION
Similarly to what was observed for `joinAssay` (issue #78), `aggregateFeatures` needed to be adapted to preserve the class of the input assay. For example, aggregating à `SingleCellExperiment` should create a new `SingleCellExperiment`. The associated unit tests are also provided by this PR.