### PR TITLE
perf: removed unnecessary subsetting in `subsetByFeatures`

### DIFF
--- a/R/subsetBy-methods.R
+++ b/R/subsetBy-methods.R
@@ -87,8 +87,6 @@ setMethod("subsetByFeature", c("QFeatures", "character"),
     all_assays_names <- find_assays_from(x, leaf_assay_name)
     all_assays_names <- unique(as.vector(all_assays_names))
 
-    ans <- x[, , all_assays_names]
-
     ## Let's first collect the feature names for all assays
     featurename_list <- vector("list", length = length(all_assays_names))
     names(featurename_list) <- all_assays_names


### PR DESCRIPTION
While I was trying to improve the performance of the `subsetByFeatures` method, I realized there is a line that seemed unnecessary to me. It creates an `ans` variable that is never called later in the function. I took the liberty to remove the line. Unit tests throw no error. 