### PR TITLE
fix: solves issue #100 about joining assays

### DIFF
--- a/R/QFeatures-join.R
+++ b/R/QFeatures-join.R
@@ -9,7 +9,7 @@
     .x <- x[k, , drop = FALSE]
     .y <- y[k, , drop = FALSE]
     for (j in names(.x))
-        if (!isTRUE(all.equal(.x[[j]], .y[[j]])))
+        if (!isTRUE(identical(.x[[j]], .y[[j]])))
             x[, j] <- y[, j] <- NULL
     ## Create these to recover rownames
     x$._rownames <- rownames(x)


### PR DESCRIPTION
See issue #100 for background information. 

The `all.equal` call in the function check is replaced in the `identical` as was suggested.

All unit tests pass without he need for further changes. 
