### PR TITLE
refactor: optimized 'infIsNA' and 'zeroIsNA'

### DIFF
--- a/R/QFeatures-missing-data.R
+++ b/R/QFeatures-missing-data.R
@@ -171,9 +171,12 @@ setMethod("zeroIsNA", c("SummarizedExperiment", "missing"),
 ##' @rdname QFeatures-missing-data
 setMethod("zeroIsNA", c("QFeatures", "integer"),
           function(object, i) {
+              el <- experiments(object)
               for (ii in i)
-                  object[[ii]] <- zeroIsNA(object[[ii]])
-              object
+                  el[[ii]] <- zeroIsNA(el[[ii]])
+              BiocGenerics:::replaceSlots(object,
+                                          ExperimentList = el,
+                                          check = TRUE)
           })
 
 ##' @rdname QFeatures-missing-data
@@ -183,9 +186,9 @@ setMethod("zeroIsNA", c("QFeatures", "numeric"),
 ##' @rdname QFeatures-missing-data
 setMethod("zeroIsNA", c("QFeatures", "character"),
           function(object, i) {
-              for (ii in i)
-                  object[[ii]] <- zeroIsNA(object[[ii]])
-              object
+              if (any(! i %in% names(object)))
+                  stop("subscript contains invalid names")
+              zeroIsNA(object, which(names(object) %in% i))
           })
 
 
@@ -200,9 +203,12 @@ setMethod("infIsNA", c("SummarizedExperiment", "missing"),
 ##' @rdname QFeatures-missing-data
 setMethod("infIsNA", c("QFeatures", "integer"),
           function(object, i) {
+              el <- experiments(object)
               for (ii in i)
-                  object[[ii]] <- infIsNA(object[[ii]])
-              object
+                  el[[ii]] <- infIsNA(el[[ii]])
+              BiocGenerics:::replaceSlots(object,
+                                          ExperimentList = el,
+                                          check = TRUE)
           })
 
 ##' @rdname QFeatures-missing-data
@@ -212,9 +218,9 @@ setMethod("infIsNA", c("QFeatures", "numeric"),
 ##' @rdname QFeatures-missing-data
 setMethod("infIsNA", c("QFeatures", "character"),
           function(object, i) {
-              for (ii in i)
-                  object[[ii]] <- infIsNA(object[[ii]])
-              object
+              if (any(! i %in% names(object)))
+                  stop("subscript contains invalid names")
+              infIsNA(object, which(names(object) %in% i))
           })
 
 


### PR DESCRIPTION
I noticed that `infIsNA` and `zeroIsNA` replace assays in a loop what leads to calling `MultiAssayExperiment:::.harmonize` at each iteration, which is very slow (see also https://github.com/waldronlab/MultiAssayExperiment/pull/297). 

I now extract the `ExperimentList` and modify it in the loop (very fast) and then replace that slot of the `QFeatures` object with the modified list. `BiocGenerics:::replaceSlots` checks the validity of the object. 

Note: the speed could further be increased by setting `check = FALSE` in the `BiocGenerics:::replaceSlots`. Since we know by the design of `zeroIsNA, SummarizedExperiments` that nothing changes except the quantification tables, we know the returned object is valid. 