### PR TITLE
fix: avoided warnings thrown by 'MultiAssayExperiment'

### DIFF
--- a/R/QFeatures-join.R
+++ b/R/QFeatures-join.R
@@ -152,7 +152,7 @@ joinAssays <- function(x,
               "Need at least 2 assays to join" = length(i) >= 2)
     if (name %in% names(x))
         stop("Assay with name '", name, "' already exists.")
-    joined_se <- mergeSElist(as.list(experiments(x[, , i])))
+    joined_se <- mergeSElist(as.list(experiments(x)[i]))
     x <- addAssay(x, joined_se, name = name)
     ## Add the multi-parent AssayLinks
     if (is.numeric(i)) i <- names(x)[i]

--- a/tests/testthat/test_Features.R
+++ b/tests/testthat/test_Features.R
@@ -46,10 +46,14 @@ test_that("addAssay", {
 test_that("[,QFeatures", {
     data(feat1)
     feat1 <- aggregateFeatures(feat1, "psms", "Sequence", "peptides")
-    expect_true(validObject(feat1[, , "psms"]))
-    expect_true(validObject(feat1[, , "peptides"]))
-    expect_true(validObject(feat1[, , 1]))
-    expect_true(validObject(feat1[, , 2]))
+    expect_true(expect_warning(validObject(feat1[, , "psms"]),
+                               regexp = "'experiments' dropped; see 'metadata'"))
+    expect_true(expect_warning(validObject(feat1[, , "peptides"]),
+                               regexp = "'experiments' dropped; see 'metadata'"))
+    expect_true(expect_warning(validObject(feat1[, , 1]),
+                               regexp = "'experiments' dropped; see 'metadata'"))
+    expect_true(expect_warning(validObject(feat1[, , 2]),
+                               regexp = "'experiments' dropped; see 'metadata'"))
 })
 
 
@@ -151,3 +155,4 @@ test_that("longFormat", {
     expect_error(longFormat(feat2, rowDataCols = "y"),
                  regexp = "not found")
 })
+

--- a/tests/testthat/test_filterFeatures.R
+++ b/tests/testthat/test_filterFeatures.R
@@ -28,11 +28,11 @@ test_that("filterFeatures", {
     ## Test no match filters
     filter1 <- filterFeatures(feat1, ~  location != "Mitochondrion")
     expect_identical(lengths(filter1), c(4L, 1L, 1L))
-    expect_true(isEmpty(filterFeatures(feat1, VariableFilter("location", "not"))))
-    expect_true(isEmpty(filterFeatures(feat1, ~ location == "not")))
-    expect_true(isEmpty(filterFeatures(feat1, VariableFilter("foo", "bar"))))
-    expect_true(isEmpty(filterFeatures(feat1, ~ foo == "bar")))
-    expect_true(isEmpty(filterFeatures(feat1, ~ is.na(pval))))
+    expect_true(all(dims(filterFeatures(feat1, VariableFilter("location", "not")))[1, ] == 0))
+    expect_true(all(dims(filterFeatures(feat1, ~ location == "not"))[1, ] == 0))
+    expect_true(all(dims(filterFeatures(feat1, VariableFilter("foo", "bar")))[1, ] == 0))
+    expect_true(all(dims(filterFeatures(feat1, ~ foo == "bar"))[1, ] == 0))
+    expect_true(all(dims(filterFeatures(feat1, ~ is.na(pval)))[1, ] == 0))
     
     ## Test fraud filters
     expect_error(VariableFilter("pval", TRUE, "<="))

--- a/tests/testthat/test_impute.R
+++ b/tests/testthat/test_impute.R
@@ -8,9 +8,18 @@ test_that("impute: mandatory method", {
     expect_error(impute(se_na2, method = "not"))
 })
 
+test_that("impute: test warning", {
+    data(se_na2)
+    ## Get the number of rows with more than 50% missing
+    nnarows <- sum(rowMeans(is.na(assay(se_na2))) > 0.5)
+    ## Test warning
+    expect_warning(impute(se_na2, method = "knn"),
+                   regexp = paste0(nnarows, " rows with more than 50 %"))
+})
+
 test_that("impute: absence of missing values", {
     data(se_na2)
-    se_imp <- impute(se_na2, method = "knn")
+    se_imp <- expect_warning(impute(se_na2, method = "knn"))
     se_imp_2 <- impute(se_imp, method = "knn")
     expect_identical(se_imp, se_imp_2)
 })
@@ -18,8 +27,8 @@ test_that("impute: absence of missing values", {
 test_that("impute,SummarizedExperiment", {
     data(se_na2)
     x <- assay(se_na2)
-    se_imp <- impute(se_na2, method = "knn")
-    x_imp <- MsCoreUtils::impute_matrix(x, method = "knn")
+    se_imp <- expect_warning(impute(se_na2, method = "knn"))
+    x_imp <- expect_warning(MsCoreUtils::impute_matrix(x, method = "knn"))
     expect_identical(x_imp, assay(se_imp))
 })
 

--- a/tests/testthat/test_missing-data.R
+++ b/tests/testthat/test_missing-data.R
@@ -64,13 +64,13 @@ test_that("function: .nNAByAssay, .nNAByMargin, .nNA, and .nNAi", {
     ## .nNAByMargin by row
     expect_identical(n_na$nNArows,
                      DataFrame(assay = rep(names(ft0)[1:2], each = 4),
-                               name = unlist(rownames(ft0[, , 1:2]), 
+                               name = unlist(rownames(ft0)[1:2], 
                                              use.names = FALSE),
                                nNA = nNArows, pNA = pNArows))
     ## .nNAByMargin by column
     expect_identical(n_na$nNAcols,
                      DataFrame(assay = rep(names(ft0)[1:2], each = 3),
-                               name = unlist(colnames(ft0[, , 1:2]), 
+                               name = unlist(colnames(ft0)[1:2], 
                                              use.names = FALSE),
                                nNA = nNAcols, 
                                pNA = pNAcols))


### PR DESCRIPTION
Starting to solve the identified issues as listed in https://github.com/rformassspectrometry/QFeatures/issues/125:

- [x] `test_Features.R`: we are checking the QFeatures subsetting method. MAE throws an error as soon as an assay is removed. I think we could simply catch the warning with no further change, what do you think?
- [ ] `test_filerFeatures.R` and `test_subsetByFeatures`: assays that contain 0 features or 0 columns are no longer removed from the object when performing subsetting with [. Some tests in test_filerFeatures.R are expecting empty objects but this does no longer happen. BUT subsetByFeatures does remove empty assays. There is a diverging behavior between [ and subsetByFeatures. What behavior should we keep for QFeatures? I would prefer the [ behavior (with a drop argument) since this is in line with MAE.
- [x] `test_join.R`: a warning is thrown because joinAssays performs an internal subsetting. This can be easily avoided with a little refactoring.
- [x] `test_missing-data.R`: can be easily avoided with a little refactoring in the tests.

