### PR TITLE
fix: fixed unexpected behavior when ecol is logical

### DIFF
--- a/R/QFeatures-constructors.R
+++ b/R/QFeatures-constructors.R
@@ -87,7 +87,7 @@ readSummarizedExperiment <- function(table, ecol, fnames, ...) {
         args$stringsAsFactors <- FALSE
         xx <- do.call(read.csv, args)
     }
-    if (is.character(ecol)) {
+    if (is.character(ecol) || is.factor(ecol)) {
         ecol0 <- ecol
         ecol <- match(ecol0, colnames(xx))
         if (any(is.na(ecol)))

--- a/R/QFeatures-constructors.R
+++ b/R/QFeatures-constructors.R
@@ -95,6 +95,9 @@ readSummarizedExperiment <- function(table, ecol, fnames, ...) {
                  paste(ecol0[is.na(ecol)], collapse = ", "),
                  " not recognised among\n",
                  paste(colnames(xx), paste = ", "))
+    } else if (is.logical(ecol)) {
+        if (length(ecol) != length(xx)) stop("Length of 'ecol' and 'table' do not match.")
+        ecol <- which(ecol)
     }
     assay <- as.matrix(xx[, ecol, drop = FALSE])
     fdata <- DataFrame(xx[, -ecol, drop = FALSE])

--- a/tests/testthat/test_readFeatures.R
+++ b/tests/testthat/test_readFeatures.R
@@ -37,21 +37,21 @@ test_that("readSummarizedExperiment", {
     ft1 <- readSummarizedExperiment(x, ecol = 1:10)
     ft2 <- readSummarizedExperiment(f, ecol = 1:10)
     expect_equal(ft1, ft2)
-    ft1 <- readSummarizedExperiment(x, ecol = 1:10, fname = "Sequence")
-    ft2 <- readSummarizedExperiment(f, ecol = 1:10, fname = "Sequence")
-    expect_equal(ft1, ft2)
-    ft3 <- readSummarizedExperiment(f, ecol = 1:10, fname = 11)
-    expect_equal(ft1, ft3)
+    ft3 <- readSummarizedExperiment(x, ecol = 1:10, fname = "Sequence")
+    ft4 <- readSummarizedExperiment(f, ecol = 1:10, fname = "Sequence")
+    expect_equal(ft3, ft4)
+    ft5 <- readSummarizedExperiment(f, ecol = 1:10, fname = 11)
+    expect_equal(ft3, ft5)
     ## Read data with only 1 quantitation column
-    ft4 <- readSummarizedExperiment(f, ecol = 1, fname = 11)
+    ft5 <- readSummarizedExperiment(f, ecol = 1, fname = 11)
     ## Check column names
     ecol <- c("X126", "X127C", "X127N", "X128C", "X128N", "X129C",
               "X129N", "X130C", "X130N", "X131")
-    expect_identical(colnames(ft1), ecol)
-    expect_identical(colnames(ft4), ecol[1])
+    expect_identical(colnames(ft3), ecol)
+    expect_identical(colnames(ft5), ecol[1])
     ## Provide ecol as logical 
     ecol <- seq_along(x) %in% 1:10
-    expect_identical(ft1, readSummarizedExperiment(f, ecol = ecol))
+    expect_identical(ft1, readSummarizedExperiment(x, ecol = ecol))
     
     ## Expect errors
     ecol <- LETTERS[1:10]

--- a/tests/testthat/test_readFeatures.R
+++ b/tests/testthat/test_readFeatures.R
@@ -49,6 +49,10 @@ test_that("readSummarizedExperiment", {
               "X129N", "X130C", "X130N", "X131")
     expect_identical(colnames(ft1), ecol)
     expect_identical(colnames(ft4), ecol[1])
+    ## Provide ecol as logical 
+    ecol <- seq_along(x) %in% 1:10
+    expect_identical(ft1, readSummarizedExperiment(f, ecol = ecol))
+    
     ## Expect errors
     ecol <- LETTERS[1:10]
     expect_error(readSummarizedExperiment(x, ecol = ecol, name = "psms"))


### PR DESCRIPTION
I adapted `readSummarizedExperiment` and created a related unit test. 