### PR TITLE
Fixed bug that produced invalid AssayLinks when using filterNA (cf #141)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## QFeatures 1.3.4
 
-- Nothing yet.
+- Fixed bug that produced invalid AssayLinks when using filterNA.
 
 ## QFeatures 1.3.3
 

--- a/R/QFeatures-missing-data.R
+++ b/R/QFeatures-missing-data.R
@@ -259,9 +259,10 @@ setMethod("filterNA", "SummarizedExperiment",
 ##' @rdname QFeatures-missing-data
 setMethod("filterNA", "QFeatures",
           function(object, pNA = 0, i) {
-              if (missing(i))
-                  stop("'i' not provided. You must specify which assay(s) to process.")
-              for (ii in i)
-                  object[[ii]] <- filterNA(object[[ii]], pNA)
-              object
+              if (!is.character(i)) i <- names(object)[i]
+              sel <- lapply(i, function(ii) {
+                  .row_for_filterNA(assay(object[[ii]]), pNA)
+              })
+              names(sel) <- i 
+              object[sel, ]
           })

--- a/tests/testthat/test_missing-data.R
+++ b/tests/testthat/test_missing-data.R
@@ -155,15 +155,15 @@ test_that("nNA,SummarizedExperiment and nNA,QFeatures", {
 })
 
 test_that("filterNA,QFeatures and filterNA,SummarizedExperiment", {
-    se_na_filtered <- filterNA(se_na)
-    expect_error(filterNA(ft0))
-    ft_filtered <- filterNA(ft0, i = seq_along(ft0))
-    expect_equivalent(se_na_filtered, ft_filtered[[1]])
+    ## filterNA on SE
+    ## se_na contains 1 NA in 3 rows. Removing all rows with NA results
+    ## in an assay with 1 row and 3 colums
+    se_na_filtered <- filterNA(se_na, pNA = 0)
+    expect_identical(dim(se_na_filtered), c(1L, 3L))
     expect_identical(assay(se_na_filtered), m[2, , drop = FALSE])
-    se_na_filtered <- filterNA(se_na, pNA = 0.9)
-    ft_filtered <- filterNA(ft0, i = seq_along(ft0), pNA = 0.9)
-    expect_equivalent(se_na_filtered, ft_filtered[[1]])
-    expect_equivalent(se_na_filtered, ft0[[2]])
+    ## filterNA on QFeatures
+    ft_filtered <- filterNA(ft0, i = seq_along(ft0), pNA = 0)
+    expect_identical(se_na_filtered, ft_filtered[[1]])
 })
 
 test_that("aggregateFeatures with missing data", {
@@ -188,4 +188,8 @@ test_that("aggregateFeatures with missing data", {
                     .n = c(2L, 2L),
                     row.names = 1:2)
     expect_equivalent(rowData(ft_na[[2]]), rd)
+    ## Check filterNA on linked assays
+    expect_true(
+        validObject(filterNA(ft_na, i = seq_along(ft_na), pNA = 0.5))
+    )
 })


### PR DESCRIPTION
Fixed small bug in code so that `filterNA` now correctly subsets the `AssayLinks`. 