### PR TITLE
Optimisation of aggregateFeatures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .Rproj.user
 vignettes/QFeatures.html
 vignettes/QFeatures_files
+*.Rproj
+.Rhistory

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,10 @@ Authors@R: c(person("Laurent", "Gatto",
              person("Christophe", "Vanderaa",
                     email = "christophe.vanderaa@uclouvain.be",
                     comment = c(ORCID = "0000-0001-7443-5427"),
-                    role = "aut"))
+                    role = "aut"),
+             person("Léopold", "Guyot", 
+                     email = "leopold.guyot@ulb.be",
+                     role = "ctb"))
 Description: The QFeatures infrastructure enables the management and
    processing of quantitative features for high-throughput mass
    spectrometry assays. It provides a familiar Bioconductor user

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,8 @@
 
 ## QFeatures 1.17.4
 
-- Nothing yet.
+- Optimisation of `aggregateFeatures` in the case of 
+multiple assays aggregation.
 
 ## QFeatures 1.17.3
 

--- a/R/QFeatures-aggregation.R
+++ b/R/QFeatures-aggregation.R
@@ -1,36 +1,42 @@
-##' @title Aggregate an assay's quantitative features
+##' @title Aggregate assays' quantitative features
 ##'
 ##' @description
 ##'
-##' This function aggregates the quantitative features of an assay,
-##' applying a summarisation function (`fun`) to sets of features.
+##' This function aggregates the quantitative features of one or
+##' multiple assays, applying a summarisation function (`fun`) to
+##' sets of features.
 ##' The `fcol` variable name points to a rowData column that defines
 ##' how to group the features during aggregate. This variable can
 ##' eigher be a vector (we then refer to an *aggregation by vector*)
 ##' or an adjacency matrix (*aggregation by matrix*).
 ##'
-##' The rowData of the aggregated `SummarizedExperiment` assay
+##' The rowData of the aggregated `SummarizedExperiment` assays
 ##' contains a `.n` variable that provides the number of parent
 ##' features that were aggregated.
 ##'
 ##' When aggregating with a vector, the newly aggregated
-##' `SummarizedExperiment` assay also contains a new `aggcounts` assay
+##' `SummarizedExperiment` assays also contains a new `aggcounts` assay
 ##' containing the aggregation counts matrix, i.e. the number of
 ##' features that were aggregated for each sample, which can be
 ##' accessed with the `aggcounts()` accessor.
 ##'
+##' Only the rowData columns that are invariant within a group across
+##' all assays will be retained in the new assays' rowData.
+##'
 ##' @param object An instance of class [QFeatures] or [SummarizedExperiment].
 ##'
-##' @param i The index or name of the assay which features will be
-##'     aggregated the create the new assay.
+##' @param i A `numeric()` or `character()` indicating the index or name
+##'     of one or multiple assays that will be aggregated
+##'     to create one or multiple new assays.
 ##'
 ##' @param fcol A `character(1)` naming a rowdata variable (of assay
 ##'     `i` in case of a `QFeatures`) defining how to aggregate the
-##'     features of the assay. This variable is either a `character`
+##'     features of the assays. This variable is either a `character`
 ##'     or a (possibly sparse) matrix. See below for details.
 ##'
-##' @param name A `character(1)` naming the new assay. Default is
-##'     `newAssay`. Note that the function will fail if there's
+##' @param name A `character()` naming the new assays.
+##'     name must have the same length as i.
+##'     Default is `newAssay`. Note that the function will fail if there's
 ##'     already an assay with `name`.
 ##'
 ##' @param fun A function used for quantitative feature
@@ -263,11 +269,16 @@ setMethod("aggregateFeatures", "QFeatures",
               if (length(i) != length(name)) stop("'i' and 'name' must have same length")
               if (length(fcol) == 1) fcol <- rep(fcol, length(i))
               if (length(i) != length(fcol)) stop("'i' and 'fcol' must have same length")
+              rowDataColsKept <- colnames(rowData(object[[i[1]]]))
               ## Aggregate each assay
               for (j in seq_along(i)) {
                   from <- i[[j]]
                   to <- name[[j]]
                   by <- fcol[[j]]
+                  ## Remove already discarded columns from rowData
+                  rowDataColsKept <- intersect(rowDataColsKept,
+                                               colnames(rowData(object[[from]])))
+                  rowData(object[[from]]) <- rowData(object[[from]])[, rowDataColsKept, drop = FALSE]
                   ## Create the aggregated assay
                   aggAssay <- .aggregateQFeatures(object[[from]],
                                                   by, fun, ...)
@@ -277,6 +288,13 @@ setMethod("aggregateFeatures", "QFeatures",
                   object <- addAssayLink(object, from = from,
                                          to  = to, varFrom = by,
                                          varTo = by)
+                  ## Update invariant colnames
+                  rowDataColsKept <- colnames(rowData(aggAssay))
+              }
+              for (j in name) {
+                  rowDataColsKept <- intersect(rowDataColsKept,
+                                               colnames(rowData(object[[j]])))
+                  rowData(object[[j]]) <- rowData(object[[j]])[, rowDataColsKept]
               }
               object
           })

--- a/R/QFeatures-aggregation.R
+++ b/R/QFeatures-aggregation.R
@@ -35,7 +35,7 @@
 ##'     or a (possibly sparse) matrix. See below for details.
 ##'
 ##' @param name A `character()` naming the new assays.
-##'     name must have the same length as i.
+##'     `name` must have the same length as i.
 ##'     Default is `newAssay`. Note that the function will fail if there's
 ##'     already an assay with `name`.
 ##'

--- a/man/QFeatures-aggregate.Rd
+++ b/man/QFeatures-aggregate.Rd
@@ -44,7 +44,7 @@ features of the assays. This variable is either a \code{character}
 or a (possibly sparse) matrix. See below for details.}
 
 \item{name}{A \code{character()} naming the new assays.
-name must have the same length as i.
+\code{name} must have the same length as i.
 Default is \code{newAssay}. Note that the function will fail if there's
 already an assay with \code{name}.}
 

--- a/man/QFeatures-aggregate.Rd
+++ b/man/QFeatures-aggregate.Rd
@@ -10,7 +10,7 @@
 \alias{adjacencyMatrix,QFeatures-method}
 \alias{aggregateFeatures,SummarizedExperiment-method}
 \alias{adjacencyMatrix<-}
-\title{Aggregate an assay's quantitative features}
+\title{Aggregate assays' quantitative features}
 \usage{
 \S4method{aggregateFeatures}{QFeatures}(
   object,
@@ -40,11 +40,12 @@ adjacency matrix will be added to. Ignored when \code{x} is an
 
 \item{fcol}{A \code{character(1)} naming a rowdata variable (of assay
 \code{i} in case of a \code{QFeatures}) defining how to aggregate the
-features of the assay. This variable is either a \code{character}
+features of the assays. This variable is either a \code{character}
 or a (possibly sparse) matrix. See below for details.}
 
-\item{name}{A \code{character(1)} naming the new assay. Default is
-\code{newAssay}. Note that the function will fail if there's
+\item{name}{A \code{character()} naming the new assays.
+name must have the same length as i.
+Default is \code{newAssay}. Note that the function will fail if there's
 already an assay with \code{name}.}
 
 \item{fun}{A function used for quantitative feature
@@ -65,22 +66,26 @@ A \code{QFeatures} object with an additional assay or a
 \code{SummarizedExperiment} object (or subclass thereof).
 }
 \description{
-This function aggregates the quantitative features of an assay,
-applying a summarisation function (\code{fun}) to sets of features.
+This function aggregates the quantitative features of one or
+multiple assays, applying a summarisation function (\code{fun}) to
+sets of features.
 The \code{fcol} variable name points to a rowData column that defines
 how to group the features during aggregate. This variable can
 eigher be a vector (we then refer to an \emph{aggregation by vector})
 or an adjacency matrix (\emph{aggregation by matrix}).
 
-The rowData of the aggregated \code{SummarizedExperiment} assay
+The rowData of the aggregated \code{SummarizedExperiment} assays
 contains a \code{.n} variable that provides the number of parent
 features that were aggregated.
 
 When aggregating with a vector, the newly aggregated
-\code{SummarizedExperiment} assay also contains a new \code{aggcounts} assay
+\code{SummarizedExperiment} assays also contains a new \code{aggcounts} assay
 containing the aggregation counts matrix, i.e. the number of
 features that were aggregated for each sample, which can be
 accessed with the \code{aggcounts()} accessor.
+
+Only the rowData columns that are invariant within a group across
+all assays will be retained in the new assays' rowData.
 }
 \details{
 Aggregation is performed by a function that takes a matrix as

--- a/man/QFeatures-class.Rd
+++ b/man/QFeatures-class.Rd
@@ -25,7 +25,7 @@
 \alias{longFormat}
 \alias{removeAssay}
 \alias{replaceAssay}
-\alias{[[<-,QFeatures,ANY,ANY-method}
+\alias{[[<-,QFeatures,ANY,ANY,ANY-method}
 \alias{updateObject,QFeatures-method}
 \alias{dropEmptyAssays}
 \title{Quantitative MS QFeatures}
@@ -70,7 +70,7 @@ removeAssay(x, i)
 
 replaceAssay(x, y, i)
 
-\S4method{[[}{QFeatures,ANY,ANY}(x, i, j, ...) <- value
+\S4method{[[}{QFeatures,ANY,ANY,ANY}(x, i, j, ...) <- value
 
 \S4method{updateObject}{QFeatures}(object, ..., verbose = FALSE)
 

--- a/man/QFeatures-class.Rd
+++ b/man/QFeatures-class.Rd
@@ -25,7 +25,7 @@
 \alias{longFormat}
 \alias{removeAssay}
 \alias{replaceAssay}
-\alias{[[<-,QFeatures,ANY,ANY,ANY-method}
+\alias{[[<-,QFeatures,ANY,ANY-method}
 \alias{updateObject,QFeatures-method}
 \alias{dropEmptyAssays}
 \title{Quantitative MS QFeatures}
@@ -70,7 +70,7 @@ removeAssay(x, i)
 
 replaceAssay(x, y, i)
 
-\S4method{[[}{QFeatures,ANY,ANY,ANY}(x, i, j, ...) <- value
+\S4method{[[}{QFeatures,ANY,ANY}(x, i, j, ...) <- value
 
 \S4method{updateObject}{QFeatures}(object, ..., verbose = FALSE)
 

--- a/tests/testthat/test_aggregateFeatures.R
+++ b/tests/testthat/test_aggregateFeatures.R
@@ -272,3 +272,23 @@ test_that("aggregateFeatures,QFeatures: aggregate multiple assays", {
                                    fun = colSums),
                  regexp = "'i' and 'fcol' must have same length")
 })
+
+test_that("aggregateFeatures,QFeatures: invariant columns discarded", {
+    data("feat3")
+    expect_warning(feat3 <- feat3[, , 1:3],
+                   regexp = "experiments' dropped; see 'drops")
+    ii <- names(feat3)
+    for (i in ii) {
+       rowData(feat3[[i]])$variant <- seq_along(nrow(rowData(feat3[[i]])))
+    }
+    rowData(feat3[[1]])$psms1col <- 1
+
+   feat3aggr <- aggregateFeatures(feat3, i = ii, fcol = "Protein",
+                                       name = paste0("prots", 1:3),
+                                       fun = colSums)
+    ## Checking the aggregated assay rowData doesn't contain the variant columns
+    expect_identical(dims(feat3aggr),
+                     matrix(c(7L, 8L, 10L, rep(2L, 3), rep(c(2L, 2L, 4L), 2)),
+                            nrow = 2, byrow = TRUE,
+                            dimnames = list(NULL, c(ii, paste0("prots", 1:3)))))
+})

--- a/tests/testthat/test_aggregateFeatures.R
+++ b/tests/testthat/test_aggregateFeatures.R
@@ -287,8 +287,8 @@ test_that("aggregateFeatures,QFeatures: invariant columns discarded", {
                                        name = paste0("prots", 1:3),
                                        fun = colSums)
     ## Checking the aggregated assay rowData doesn't contain the variant columns
-    expect_identical(dims(feat3aggr),
-                     matrix(c(7L, 8L, 10L, rep(2L, 3), rep(c(2L, 2L, 4L), 2)),
-                            nrow = 2, byrow = TRUE,
-                            dimnames = list(NULL, c(ii, paste0("prots", 1:3)))))
+    expect_identical(dims(rowData(feat3aggr)),
+                     matrix(c(7L, 7L, 8L, 3L, 10L, 3L, rep(c(2L, 4L), 3)),
+                            nrow = 6, byrow = TRUE,
+                            dimnames = list(c(ii, paste0("prots", 1:3)), NULL)))
 })


### PR DESCRIPTION
Optimisation of `aggregateFeatures` when aggregating multiple assays.

Context: [scp Optimisation of aggregateFeaturesOverAssays #80 ](https://github.com/UCLouvain-CBIO/scp/pull/80)

I updated the docs and added a unit test to check that the variant columns are discarded.

A new benchmark is on the way.

@lgatto @cvanderaa