### PR TITLE
readQFeatures(): don't ignore colData$quantCols

### DIFF
--- a/R/readQFeatures.R
+++ b/R/readQFeatures.R
@@ -499,7 +499,16 @@ readQFeatures <- function(assayData,
     if (is.null(colData))
         return(DataFrame(row.names = sampleNames))
     if (!length(runs)) {
-        rownames(colData) <- sampleNames
+        if ("quantCols" %in% colnames(colData)) {
+            # use quantCols column as quantCols argument
+            # can have different ordering
+            rownames(colData) <- colData$quantCols
+        } else if (length(quantCols) == nrow(colData)) {
+            # no quantCols column, we prioritize quantCols argument
+            rownames(colData) <- quantCols
+        } else {
+            rownames(colData) <- sampleNames
+        }
     } else {
         if (length(quantCols) == 1) {
             rownames(colData) <- colData$runCol

--- a/R/readQFeatures.R
+++ b/R/readQFeatures.R
@@ -499,23 +499,28 @@ readQFeatures <- function(assayData,
     if (is.null(colData))
         return(DataFrame(row.names = sampleNames))
     if (!length(runs)) {
+        # assign colData rownames to match colData to sampleNames
         if ("quantCols" %in% colnames(colData)) {
-            # use quantCols column as quantCols argument
-            # can have different ordering
+            # use colData$quantCols as rownames
+            # (quantCols argument is not guaranteed to match to colData rows)
             rownames(colData) <- colData$quantCols
         } else if (length(quantCols) == nrow(colData)) {
-            # no quantCols column, we prioritize quantCols argument
+            # no colData$quantCols column
+            # we assume the colData order matches quantCols argument
             rownames(colData) <- quantCols
         } else {
+            # assume colData order matches sampleNames
             rownames(colData) <- sampleNames
         }
     } else {
+        # run information is present, colData should match individual runs
         if (length(quantCols) == 1) {
             rownames(colData) <- colData$runCol
         } else {
             rownames(colData) <- paste0(colData$runCol, "_", colData$quantCols)
         }
     }
+    # match colData to sampleNames
     colData <- colData[sampleNames, , drop = FALSE]
     rownames(colData) <- sampleNames ## clean NA in rownames
     colData

--- a/R/readQFeatures.R
+++ b/R/readQFeatures.R
@@ -336,7 +336,7 @@ readQFeatures <- function(assayData,
     }
     if (removeEmptyCols) el <- .removeEmptyColumns(el)
     if (verbose) message("Formatting sample annotations (colData).")
-    colData <- .formatColData(el, colData, runs, quantCols)
+    colData <- .formatColData(el, colData, runs)
     if (verbose) message("Formatting data as a 'QFeatures' object.")
     ans <- QFeatures(experiments = el, colData = colData)
     if (!is.null(fnames)) {
@@ -494,31 +494,19 @@ readQFeatures <- function(assayData,
 
 ## This function will create a colData from the different (possibly
 ## missing, i.e. NULL) arguments
-.formatColData <- function(el, colData, runs, quantCols) {
+.formatColData <- function(el, colData, runs) {
     sampleNames <- unlist(lapply(el, colnames), use.names = FALSE)
     if (is.null(colData))
         return(DataFrame(row.names = sampleNames))
-    if (!length(runs)) {
-        # assign colData rownames to match colData to sampleNames
-        if ("quantCols" %in% colnames(colData)) {
-            # use colData$quantCols as rownames
-            # (quantCols argument is not guaranteed to match to colData rows)
-            rownames(colData) <- colData$quantCols
-        } else if (length(quantCols) == nrow(colData)) {
-            # no colData$quantCols column
-            # we assume the colData order matches quantCols argument
-            rownames(colData) <- quantCols
-        } else {
-            # assume colData order matches sampleNames
-            rownames(colData) <- sampleNames
-        }
+    # assign colData rownames to match colData to sampleNames
+    # colData$quantCols presence was checked by .checkQuantCols
+    if (is.null(runs)) {
+        # use colData$quantCols as rownames
+        rownames(colData) <- colData$quantCols
     } else {
         # run information is present, colData should match individual runs
-        if (length(quantCols) == 1) {
-            rownames(colData) <- colData$runCol
-        } else {
-            rownames(colData) <- paste0(colData$runCol, "_", colData$quantCols)
-        }
+        # the presence of colData$runCol was checked by .checkRunCol
+        rownames(colData) <- paste0(colData$runCol, "_", colData$quantCols)
     }
     # match colData to sampleNames
     colData <- colData[sampleNames, , drop = FALSE]

--- a/R/readQFeatures.R
+++ b/R/readQFeatures.R
@@ -506,7 +506,15 @@ readQFeatures <- function(assayData,
     } else {
         # run information is present, colData should match individual runs
         # the presence of colData$runCol was checked by .checkRunCol
-        rownames(colData) <- paste0(colData$runCol, "_", colData$quantCols)
+        if (any(duplicated(colData$runCol))) {
+            # quantCols as postfix if runCol is duplicated
+            newRownames <- paste0(colData$runCol, "_", colData$quantCols)
+            if (any(duplicated(newRownames)))
+                stop("There are duplicated samples (runCol-quantCols combinations) in the colData table.")
+            rownames(colData) <- newRownames
+        } else {
+            rownames(colData) <- colData$runCol
+        }
     }
     # match colData to sampleNames
     colData <- colData[sampleNames, , drop = FALSE]

--- a/tests/testthat/test_readQFeatures.R
+++ b/tests/testthat/test_readQFeatures.R
@@ -128,12 +128,14 @@ test_that("readQFeatures: testing use cases", {
     shuffledColAnnot <- colAnnot[shuffledSamplesOrder, , drop = FALSE]
     expect_identical(
         readQFeatures(x, shuffledSamplesOrder, colData = shuffledColAnnot),
-        QFeatures(List(quants = se_exp), colData = colAnnot)
+        QFeatures(List(quants = se_exp), colData = colAnnot,
+                  metadata = list("._type" = "bulk"))
     )
     ## With colAnnot and quantCols, but with different colAnnot row order (PR #234)
     expect_identical(
         readQFeatures(x, 1:10, colData = shuffledColAnnot),
-        QFeatures(List(quants = se_exp), colData = colAnnot)
+        QFeatures(List(quants = se_exp), colData = colAnnot,
+                  metadata = list("._type" = "bulk"))
     )
 
     ## Case 2: Multiple-set, one quantitative col

--- a/tests/testthat/test_readQFeatures.R
+++ b/tests/testthat/test_readQFeatures.R
@@ -123,6 +123,18 @@ test_that("readQFeatures: testing use cases", {
         colnames(qf),
         CharacterList(quants = colnames(se_exp))
     )
+    ## With colAnnot and quantCols, but with different x columns and quantCols (PR #234)
+    shuffledSamplesOrder <- sample(1:10, 10L)
+    shuffledColAnnot <- colAnnot[shuffledSamplesOrder, , drop = FALSE]
+    expect_identical(
+        readQFeatures(x, shuffledSamplesOrder, colData = shuffledColAnnot),
+        QFeatures(List(quants = se_exp), colData = colAnnot)
+    )
+    ## With colAnnot and quantCols, but with different colAnnot row order (PR #234)
+    expect_identical(
+        readQFeatures(x, 1:10, colData = shuffledColAnnot),
+        QFeatures(List(quants = se_exp), colData = colAnnot)
+    )
 
     ## Case 2: Multiple-set, one quantitative col
     se_exp <- readSummarizedExperiment(x, 1)


### PR DESCRIPTION
I think the current version has a bug that, if there are no run information, the row names of `colData` are unconditionally assigned to the `sampleNames` (the column names of the data).
But the order of rows in colData might be different from `sampleNames`.
The correct behaviour should be to respect the `quantCols` as they are provided by the user (matching `quantCols` to `sampleNames` and reordering of colData rows happens later).

The current behaviour leads to errors in the downstream analysis (e.g. *msqrob2*), since matching data columns to the experimental design information is incorrect.

