### PR TITLE
aggregate redundant messages in aggregateFeatures + aggregateFeatures/readQFeatures progress bar

### DIFF
--- a/R/QFeatures-aggregation.R
+++ b/R/QFeatures-aggregation.R
@@ -272,20 +272,52 @@ setMethod("aggregateFeatures", "QFeatures",
 
               el <- experiments(object)[i]
               rowDataColsKept <- colnames(rowData(el[[i[1]]]))
+              msg_log <- list()
+              pb <- txtProgressBar(min = 0, max = length(i), style = 3)
+
               ## Aggregate each assay
               for (j in seq_along(i)) {
                   from <- i[[j]]
                   fromAssay <- el[[from]]
                   by <- fcol[[j]]
+                  set_name <- name[j]
+
                   ## Remove already discarded columns from rowData
-                  rowDataColsKept <- intersect(rowDataColsKept,
-                                               colnames(rowData(fromAssay)))
+                  rowDataColsKept <- intersect(
+                      rowDataColsKept,
+                      colnames(rowData(fromAssay))
+                  )
                   rowData(fromAssay) <- rowData(fromAssay)[, rowDataColsKept, drop = FALSE]
+
                   ## Create the aggregated assay
-                  el[[j]] <- aggregateFeatures(fromAssay, by, fun, ...)
+                  el[[j]] <- withCallingHandlers(
+                      aggregateFeatures(fromAssay, by, fun, ...),
+                      message = function(m) {
+                          txt <- conditionMessage(m)
+                          msg_log[[txt]] <<- unique(c(msg_log[[txt]], set_name)) 
+                          invokeRestart("muffleMessage")
+                      }
+                  )
                   rowDataColsKept <- colnames(rowData(el[[j]]))
-                  message("\rAggregated: ", j, "/", length(i))
+
+                  setTxtProgressBar(pb, j)
               }
+
+              close(pb)
+              
+              ## Aggregate shared messages
+              if (length(msg_log)) {
+                  message("The following messages occurred during aggregation:")
+
+                  for (msg in names(msg_log)) {
+                      message(
+                          "\n", msg, "\n",
+                          "Occurred during the aggregation of set(s): ",
+                          paste(msg_log[[msg]], collapse = ", ")
+                      )
+                  }
+              }
+
               names(el) <- name
               for (j in name) {
                   rowDataColsKept <- intersect(rowDataColsKept,

--- a/R/QFeatures-aggregation.R
+++ b/R/QFeatures-aggregation.R
@@ -280,7 +280,7 @@ setMethod("aggregateFeatures", "QFeatures",
                   from <- i[[j]]
                   fromAssay <- el[[from]]
                   by <- fcol[[j]]
-                  set_name <- name[j]
+                  set_name <- names(object)[[j]] 
 
                   ## Remove already discarded columns from rowData
                   rowDataColsKept <- intersect(

--- a/R/readQFeatures.R
+++ b/R/readQFeatures.R
@@ -337,7 +337,7 @@ readQFeatures <- function(assayData,
     rownames(se) <- make.unique(rownames(se))
     if (length(runs)) {
         if (verbose) message("Splitting data in runs.")
-        el <- .splitSE(se, runs)
+        el <- .splitSE(se, runs, verbose)
         el <- .createUniqueColnames(el, quantCols)
     } else {
         el <- structure(list(se), .Names = name[1])
@@ -458,7 +458,7 @@ readQFeatures <- function(assayData,
 ##'     (in that order). If a match is found, the respective variable
 ##'     is extracted, converted to a factor if needed.
 ##' @noRd
-.splitSE <- function(x, f) {
+.splitSE <- function(x, f, verbose = FALSE) {
     ## Check that f is a factor
     if (length(f) == 1) {
         if (f %in% colnames(rowData(x))) {
@@ -471,30 +471,41 @@ readQFeatures <- function(assayData,
             stop("'", f, "' not found in rowData or colData")
         }
     }
+
     ## Check that the factor matches one of the dimensions
     if (!length(f) %in% dim(x))
         stop("length(f) not compatible with dim(x).")
+
     if (length(f) == nrow(x)) {
         s <- split(rownames(x), f = f)
+        split_rows <- TRUE
     } else {
         s <- split(colnames(x), f = f)
+        split_rows <- FALSE
     }
 
-    pb <- txtProgressBar(min = 0, max = length(s), style = 3)
+    if (verbose) {
+        pb <- txtProgressBar(min = 0, max = length(s), style = 3)
+        on.exit(close(pb), add = TRUE)
+    }
 
     xl <- setNames(
         lapply(seq_along(s), function(i) {
-            setTxtProgressBar(pb, i)
-            if (length(f) == nrow(x)) x[s[[i]], ] else x[, s[[i]]]
+            if (verbose)
+                setTxtProgressBar(pb, i)
+
+            if (split_rows)
+                x[s[[i]], ]
+            else
+                x[, s[[i]]]
         }),
         names(s)
     )
 
-    close(pb)
-            
     ## Convert list to an ExperimentList
     do.call(ExperimentList, xl)
 }
+
 
 .createUniqueColnames <- function(el, quantCols) {
     if (length(quantCols) == 1)  suffix <- ""

--- a/R/readQFeatures.R
+++ b/R/readQFeatures.R
@@ -474,11 +474,24 @@ readQFeatures <- function(assayData,
     ## Check that the factor matches one of the dimensions
     if (!length(f) %in% dim(x))
         stop("length(f) not compatible with dim(x).")
-    if (length(f) == nrow(x)) { ## Split along rows
-        xl <- lapply(split(rownames(x), f = f), function(i) x[i, ])
-    } else { ## Split along columns
-        xl <- lapply(split(colnames(x), f = f), function(i) x[, i])
+    if (length(f) == nrow(x)) {
+        s <- split(rownames(x), f = f)
+    } else {
+        s <- split(colnames(x), f = f)
     }
+
+    pb <- txtProgressBar(min = 0, max = length(s), style = 3)
+
+    xl <- setNames(
+        lapply(seq_along(s), function(i) {
+            setTxtProgressBar(pb, i)
+            if (length(f) == nrow(x)) x[s[[i]], ] else x[, s[[i]]]
+        }),
+        names(s)
+    )
+
+    close(pb)
+            
     ## Convert list to an ExperimentList
     do.call(ExperimentList, xl)
 }


### PR DESCRIPTION
Hello,
Following #245.  I updated the `aggregateFeatures` function to catch and then aggregate the messages coming from the aggregation of multiple sets. I also added a progressbar as it will less flood the terminal compared to a progress indicator printed each time a set is processed. Also, following a discussion with Samuel Grégoire, we think that having a progress indicator for the `readQFeatures` function could be beneficial. I therefore implemented a progress bar for the splitting of the `SummarizedExperiment` that occurs during the `readQFeatures` execution (which is the most time consuming step).

## Before:

``` r
library(scp)
data(scp1)
aggregateFeatures(scp1, fcol = "peptide", 1:3, paste0("peptides", 1:3))
```

Output:

``` console
Your row data contain missing values. Please read the relevant
section(s) in the aggregateFeatures manual page regarding the effects
of missing values on data aggregation.
Aggregated: 1/3
Your row data contain missing values. Please read the relevant
section(s) in the aggregateFeatures manual page regarding the effects
of missing values on data aggregation.
Aggregated: 2/3
Your row data contain missing values. Please read the relevant
section(s) in the aggregateFeatures manual page regarding the effects
of missing values on data aggregation.
Aggregated: 3/3
```

## After:

``` r
library(scp)
data(scp1)
aggregateFeatures(scp1, fcol = "peptide", 1:3, paste0("peptides", 1:3))
```

Output:

``` console
  |======================================================================| 100%
The following messages occurred during aggregation:

Your row data contain missing values. Please read the relevant
section(s) in the aggregateFeatures manual page regarding the effects
of missing values on data aggregation.

Occurred during the aggregation of set(s): 190321S_LCA10_X_FP97AG, 190222S_LCA9_X_FP94BM, 190914S_LCB3_X_16plex_Set_21
```